### PR TITLE
Refactor learn process to use UI states

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,8 @@
     // Custom
     "@typescript-eslint/no-throw-literal": "off",
     "jsx-a11y/label-has-associated-control": "off",
-    "react/jsx-sort-props": "error"
+    "react/jsx-sort-props": "error",
+    "no-nested-ternary": "off"
   },
 
   "overrides": [

--- a/app/routes/$id/index.tsx
+++ b/app/routes/$id/index.tsx
@@ -33,15 +33,17 @@ export default function ShowDeck() {
       <h2>Cards</h2>
       <table>
         <thead>
-          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-          <th />
-          <th>Front</th>
-          <th>Back</th>
-          <th>Due date</th>
+          <tr>
+            {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+            <th />
+            <th>Front</th>
+            <th>Back</th>
+            <th>Due date</th>
+          </tr>
         </thead>
         <tbody>
           {data.deck.cards.map((card, index) => (
-            <tr>
+            <tr key={card.id}>
               <td>{index + 1}</td>
               <td>{card.front}</td>
               <td>{card.back}</td>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -41,7 +41,7 @@ export default function IndexPage() {
       <h2>Decks</h2>
       <ul>
         {data.decks.map((deck) => (
-          <li>
+          <li key={deck.id}>
             <Link to={deck.id}>{deck.name}</Link>
             <p>{deck.cards.length} cards</p>
             <p>{deck.quiz.length} left to learn</p>


### PR DESCRIPTION
This PR updates the learn process to use UI states. This simplifies the logic.

* showcard: show question ready to answer
* checking: user submitted answer
* showresult: display the result
* loadingnext: loading next card

I've also update the layout. It's best to try and make the layout consistent across state transitions. This way the content doesn't jump around.

I display the status text up top always, and instead of display the answer separately, I highlight the correct/wrong answer inline with the question itself.